### PR TITLE
Adding the keyboard mapping functionality

### DIFF
--- a/packages/electron/src/renderer/components/PlayerControls.tsx
+++ b/packages/electron/src/renderer/components/PlayerControls.tsx
@@ -107,11 +107,8 @@ const getKeyboardMapping = (
       "keyup",
       new Map<string, (event: KeyboardEvent) => any>([
         [" ", toggle],
-        ["spacebar", toggle],
-        // left arrow
-        [String.fromCharCode(37), onReplay],
-        // right arrow
-        [String.fromCharCode(39), onSkip],
+        ["ArrowLeft", onReplay],
+        ["ArrowRight", onSkip],
       ]),
     ],
   ]),

--- a/packages/electron/src/renderer/components/PlayerControls.tsx
+++ b/packages/electron/src/renderer/components/PlayerControls.tsx
@@ -1,4 +1,9 @@
 import React from "react";
+import {
+  IKeyboardControlsProps,
+  KeyboardControls,
+} from "./utils/keyboardControls/KeyboardControls";
+import { KeyboardEventTypes } from "./utils/keyboardControls/KeyboardEventTypes";
 
 type Controls = {
   playing: boolean;
@@ -22,9 +27,11 @@ export default function PlayerControls({
       onPlay();
     }
   }
+  const keyboardMappings = getKeyboardMapping(toggle, onReplay, onSkip);
 
   return (
     <div>
+      <KeyboardControls {...keyboardMappings} />
       <div className="absolute inset-x-0 bottom-0  py-2 ">
         <div className="flex space-x-4 justify-center items-center pb-2 text-white text-shadow-lg">
           {onReplay && (
@@ -86,3 +93,26 @@ export default function PlayerControls({
     </div>
   );
 }
+
+const getKeyboardMapping = (
+  toggle: () => any,
+  onReplay: () => any = () => {},
+  onSkip: () => any = () => {}
+): IKeyboardControlsProps => ({
+  mappings: new Map<
+    KeyboardEventTypes,
+    Map<string, (event: KeyboardEvent) => any>
+  >([
+    [
+      "keyup",
+      new Map<string, (event: KeyboardEvent) => any>([
+        [" ", toggle],
+        ["spacebar", toggle],
+        // left arrow
+        [String.fromCharCode(37), onReplay],
+        // right arrow
+        [String.fromCharCode(39), onSkip],
+      ]),
+    ],
+  ]),
+});

--- a/packages/electron/src/renderer/components/utils/keyboardControls/KeyboardControls.tsx
+++ b/packages/electron/src/renderer/components/utils/keyboardControls/KeyboardControls.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect } from "react";
+import { KeyboardEventTypes } from "./KeyboardEventTypes";
+
+export interface IKeyboardControlsProps {
+  mappings: Map<KeyboardEventTypes, Map<string, (event: KeyboardEvent) => any>>; // map both an event type (e.g: keyUp) and a key
+}
+
+// while this component could be made a function, it is more practical to have it self-contained into a function component
+// so that there is no doubt about having to remove the listener when calling it.
+export const KeyboardControls: React.FunctionComponent<IKeyboardControlsProps> = ({
+  mappings,
+}) => {
+  mappings.forEach((behaviourMap, eventName) => {
+    useEffect(() => {
+      // add the keyMatcher for each keyboardEventType
+      const keyMatcher = matchKey(behaviourMap);
+      window.addEventListener(eventName, keyMatcher);
+
+      // on unmount remove the listener
+      return () => {
+        window.removeEventListener(eventName, keyMatcher);
+      };
+    });
+  });
+
+  return <></>;
+};
+
+// This functiion uses currying since it needs to be used in addEventListener and removeEventListener
+const matchKey = (behaviourMap: Map<string, (event: KeyboardEvent) => any>) => (
+  event: KeyboardEvent
+) => {
+  const eventKey = event.key;
+  if (behaviourMap.has(eventKey)) {
+    behaviourMap.get(eventKey)!(event);
+  }
+};

--- a/packages/electron/src/renderer/components/utils/keyboardControls/KeyboardEventTypes.ts
+++ b/packages/electron/src/renderer/components/utils/keyboardControls/KeyboardEventTypes.ts
@@ -1,0 +1,1 @@
+export type KeyboardEventTypes = "keyup" | "keydown";


### PR DESCRIPTION
So, what I added is a `KeyboardControls` component (actually `FunctionComponent`) which uses hooks in order to subscribe to keyboard events and to unsubscribe when it's removed.

You can use multiple instances of this component (but beware not to register twice the same behavior) and you currently have two possibilities (which you are free to extend): keyup and keydown.
As you will see the configuration for this component is a bit complex (Map<KeyboardEventTypes, Map<string, () => any>>), the reason for this complication is so that in case you have a lot of shortcuts the access time is O(1) and not O(n).